### PR TITLE
fix issues in mio::StringReader.getline()

### DIFF
--- a/mio/include/mio/stringreader.hpp
+++ b/mio/include/mio/stringreader.hpp
@@ -36,7 +36,7 @@ namespace mio {
 
    Example:
 
-     std::filesystem::path file_path = std::filesystem::current_path()/"test.txt"; 
+     std::filesystem::path file_path = std::filesystem::current_path()/"test.txt";
      assert(std::filesystem::exists(file_path));
      mio::StringReader reader(file_path.string());
 
@@ -75,7 +75,10 @@ public:
   StringReader &operator=(StringReader &) = delete;
   StringReader &operator=(StringReader &&) = delete;
 
-  ~StringReader() = default;
+  ~StringReader()
+  {
+    m_mmap.unmap();
+  }
 
   /**
      Checks whether the reader has reached end of file.
@@ -113,15 +116,14 @@ public:
     // at the end of file. The majority of the processing will be
     // for l_find != m_mmap.end(). So we give this hint to the compiler
     // for better branch prediction.
-    if (semi_branch_expect((l_find != m_mmap.end()), true)) {
+    if (semi_branch_expect((l_find != m_mmap.end()), true))
       m_begin = std::next(l_find);
-      return {l_begin, static_cast<size_t>(l_find - l_begin - 1)}; // '\n' excluded.
-    } else {
-      m_mmap.unmap();
+    else
       m_begin = nullptr;
-      return {nullptr, 0};
-    }
+
+    return {l_begin, static_cast<size_t>(l_find - l_begin)};
   }
+
 private:
   mmap_source m_mmap;
   const char *m_begin;


### PR DESCRIPTION
Fix two potential issues regarding empty lines and the last line in mio::StringReader.getline(), which are,

1. Excluding '\n' will lead to some potential problem when a line is empty (i.e., only having '\n'). Specifically, l_find - l_begin - 1 
  will be negative and its casted value in size_t will be undefined for an empty line, which makes the returned string_view object wrong in size;
2. The original implementation will skip the last line by returning {nullptr, 0} rather than {l_begin, static_cast<size_t>(l_find - l_begin)}. On the other hand, as m_mmap is already unmapped at this point, there is no way to return the last line as {l_begin, static_cast<size_t>(l_find - l_begin)}.

- Resolve the first issue by making l_find - l_begin as the size of the returned string_view from getline().
- Resolve the second issue by removing the return statement on {nullptr, 0}, moving m_mmap.unmap() to StringReader's destructor, and placing "return {l_begin, static_cast<size_t>(l_find - l_begin)}" out of the if block.
- Trim whitespace where is needed.